### PR TITLE
refactor: BoardType 추가

### DIFF
--- a/src/main/java/com/becareful/becarefulserver/domain/community/controller/CommentController.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/controller/CommentController.java
@@ -11,23 +11,23 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/community/board/{boardId}/post/{postId}/comment")
+@RequestMapping("/community/board/{boardType}/post/{postId}/comment")
 public class CommentController {
 
     private final CommentService commentService;
 
     @PostMapping
     public ResponseEntity<Void> createComment(
-            @PathVariable Long boardId, @PathVariable Long postId, @RequestBody CommentCreateRequest request) {
-        Long commentId = commentService.createComment(boardId, postId, request);
+            @PathVariable String boardType, @PathVariable Long postId, @RequestBody CommentCreateRequest request) {
+        Long commentId = commentService.createComment(boardType, postId, request);
         return ResponseEntity.created(
-                        URI.create("/community/board/" + boardId + "/post/" + postId + "/comment/" + commentId))
+                        URI.create("/community/board/" + boardType + "/post/" + postId + "/comment/" + commentId))
                 .build();
     }
 
     @GetMapping
-    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable Long boardId, @PathVariable Long postId) {
-        var response = commentService.getComments(boardId, postId);
+    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable String boardType, @PathVariable Long postId) {
+        var response = commentService.getComments(boardType, postId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/becareful/becarefulserver/domain/community/controller/CommentController.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/controller/CommentController.java
@@ -26,7 +26,8 @@ public class CommentController {
     }
 
     @GetMapping
-    public ResponseEntity<List<CommentResponse>> getComments(@PathVariable String boardType, @PathVariable Long postId) {
+    public ResponseEntity<List<CommentResponse>> getComments(
+            @PathVariable String boardType, @PathVariable Long postId) {
         var response = commentService.getComments(boardType, postId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/controller/PostController.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/controller/PostController.java
@@ -23,39 +23,39 @@ public class PostController {
     private final PostService postService;
 
     @Operation(summary = "게시글 작성")
-    @PostMapping("/board/{boardId}/post")
-    public ResponseEntity<Void> createPost(@PathVariable Long boardId, @RequestBody PostCreateRequest request) {
-        Long postId = postService.createPost(boardId, request);
-        return ResponseEntity.created(URI.create("/board/" + boardId + "/post/" + postId))
+    @PostMapping("/board/{boardType}/post")
+    public ResponseEntity<Void> createPost(@PathVariable String boardType, @RequestBody PostCreateRequest request) {
+        Long postId = postService.createPost(boardType, request);
+        return ResponseEntity.created(URI.create("/board/" + boardType + "/post/" + postId))
                 .build();
     }
 
     @Operation(summary = "특정 게시판의 모든 게시글 리스트 조회")
-    @GetMapping("/board/{boardId}/post")
-    public ResponseEntity<List<PostSimpleDto>> getAllBoardPosts(@PathVariable Long boardId, Pageable pageable) {
-        var response = postService.getPosts(boardId, pageable);
+    @GetMapping("/board/{boardType}/post")
+    public ResponseEntity<List<PostSimpleDto>> getAllBoardPosts(@PathVariable String boardType, Pageable pageable) {
+        var response = postService.getPosts(boardType, pageable);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "특정 게시글 상세 조회", description = "특정 게시글의 상세 내용을 조회합니다.")
-    @GetMapping("/board/{boardId}/post/{postId}")
-    public ResponseEntity<PostDetailResponse> getPost(@PathVariable Long boardId, @PathVariable Long postId) {
-        var response = postService.getPost(boardId, postId);
+    @GetMapping("/board/{boardType}/post/{postId}")
+    public ResponseEntity<PostDetailResponse> getPost(@PathVariable String boardType, @PathVariable Long postId) {
+        var response = postService.getPost(boardType, postId);
         return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "게시글 수정")
-    @PutMapping("/board/{boardId}/post/{postId}")
+    @PutMapping("/board/{boardType}/post/{postId}")
     public ResponseEntity<Void> updatePost(
-            @PathVariable Long boardId, @PathVariable Long postId, @RequestBody PostUpdateRequest request) {
-        postService.updatePost(boardId, postId, request);
+            @PathVariable String boardType, @PathVariable Long postId, @RequestBody PostUpdateRequest request) {
+        postService.updatePost(boardType, postId, request);
         return ResponseEntity.ok().build();
     }
 
     @Operation(summary = "게시글 삭제")
-    @DeleteMapping("/board/{boardId}/post/{postId}")
-    public ResponseEntity<Void> deletePost(@PathVariable Long boardId, @PathVariable Long postId) {
-        postService.deletePost(boardId, postId);
+    @DeleteMapping("/board/{boardType}/post/{postId}")
+    public ResponseEntity<Void> deletePost(@PathVariable String boardType, @PathVariable Long postId) {
+        postService.deletePost(boardType, postId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/BoardType.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/BoardType.java
@@ -9,5 +9,21 @@ public enum BoardType {
     ASSOCIATION_NOTICE,
     SERVICE_NOTICE,
     INFORMATION_SHARING,
-    PARTICIPATION_APPLICATION
+    PARTICIPATION_APPLICATION;
+
+    public static BoardType fromUrlBoardType(String boardType) {
+        boardType = convertUrlBoardTypeToName(boardType);
+        for (BoardType type : BoardType.values()) {
+            if (type.name().equals(boardType)) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    private static String convertUrlBoardTypeToName(String boardType) {
+        boardType = boardType.toUpperCase();
+        String[] tokens = boardType.split("-");
+        return String.join("_", tokens);
+    }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/BoardType.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/BoardType.java
@@ -1,0 +1,13 @@
+package com.becareful.becarefulserver.domain.community.domain;
+
+public enum BoardType {
+    /**
+     * ASSOCIATION = 협회 (각 기관장이 속한 협회)
+     * INSTITUTION = 기관 (사회복지사가 소속된 기관)
+     * SERVICE = 공단 (건강보험공단)
+     **/
+    ASSOCIATION_NOTICE,
+    SERVICE_NOTICE,
+    INFORMATION_SHARING,
+    PARTICIPATION_APPLICATION
+}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/PostBoard.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/PostBoard.java
@@ -35,14 +35,16 @@ public class PostBoard extends BaseEntity {
     private Association association;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private PostBoard(BoardType boardType, AssociationRank readableRank, AssociationRank writableRank, Association association) {
+    private PostBoard(
+            BoardType boardType, AssociationRank readableRank, AssociationRank writableRank, Association association) {
         this.boardType = boardType;
         this.readableRank = readableRank;
         this.writableRank = writableRank;
         this.association = association;
     }
 
-    public static PostBoard create(BoardType boardType, AssociationRank readableRank, AssociationRank writableRank, Association association) {
+    public static PostBoard create(
+            BoardType boardType, AssociationRank readableRank, AssociationRank writableRank, Association association) {
         return PostBoard.builder()
                 .boardType(boardType)
                 .readableRank(readableRank)

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/PostBoard.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/PostBoard.java
@@ -2,16 +2,12 @@ package com.becareful.becarefulserver.domain.community.domain;
 
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.POST_BOARD_NOT_READABLE;
 
+import com.becareful.becarefulserver.domain.association.domain.Association;
 import com.becareful.becarefulserver.domain.common.domain.BaseEntity;
 import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
 import com.becareful.becarefulserver.domain.socialworker.domain.vo.AssociationRank;
 import com.becareful.becarefulserver.global.exception.exception.PostBoardException;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,7 +22,7 @@ public class PostBoard extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String name;
+    private BoardType boardType;
 
     @Enumerated(EnumType.STRING)
     private AssociationRank readableRank;
@@ -34,18 +30,24 @@ public class PostBoard extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private AssociationRank writableRank;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "association_id")
+    private Association association;
+
     @Builder(access = AccessLevel.PRIVATE)
-    private PostBoard(String name, AssociationRank readableRank, AssociationRank writableRank) {
-        this.name = name;
+    private PostBoard(BoardType boardType, AssociationRank readableRank, AssociationRank writableRank, Association association) {
+        this.boardType = boardType;
         this.readableRank = readableRank;
         this.writableRank = writableRank;
+        this.association = association;
     }
 
-    public static PostBoard create(String name, AssociationRank readableRank, AssociationRank writableRank) {
+    public static PostBoard create(BoardType boardType, AssociationRank readableRank, AssociationRank writableRank, Association association) {
         return PostBoard.builder()
-                .name(name)
+                .boardType(boardType)
                 .readableRank(readableRank)
                 .writableRank(writableRank)
+                .association(association)
                 .build();
     }
 

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/PostBoard.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/PostBoard.java
@@ -22,6 +22,7 @@ public class PostBoard extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     private BoardType boardType;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/becareful/becarefulserver/domain/community/repository/PostBoardRepository.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/repository/PostBoardRepository.java
@@ -3,9 +3,8 @@ package com.becareful.becarefulserver.domain.community.repository;
 import com.becareful.becarefulserver.domain.association.domain.Association;
 import com.becareful.becarefulserver.domain.community.domain.BoardType;
 import com.becareful.becarefulserver.domain.community.domain.PostBoard;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostBoardRepository extends JpaRepository<PostBoard, Long> {
 

--- a/src/main/java/com/becareful/becarefulserver/domain/community/repository/PostBoardRepository.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/repository/PostBoardRepository.java
@@ -1,6 +1,13 @@
 package com.becareful.becarefulserver.domain.community.repository;
 
+import com.becareful.becarefulserver.domain.association.domain.Association;
+import com.becareful.becarefulserver.domain.community.domain.BoardType;
 import com.becareful.becarefulserver.domain.community.domain.PostBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PostBoardRepository extends JpaRepository<PostBoard, Long> {}
+import java.util.Optional;
+
+public interface PostBoardRepository extends JpaRepository<PostBoard, Long> {
+
+    Optional<PostBoard> findByBoardTypeAndAssociation(BoardType boardType, Association association);
+}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
@@ -120,10 +120,12 @@ public class PostService {
 
         validateSocialWorkerRankReadable(currentMember, postBoard);
 
-        return postRepository
-                .findById(postId)
-                .map(PostDetailResponse::from)
+        Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+
+        validatePostBoardHasPost(postBoard, post);
+
+        return PostDetailResponse.from(post);
     }
 
     private void validateSocialWorkerRankWritable(SocialWorker socialworker, PostBoard board) {
@@ -141,6 +143,12 @@ public class PostService {
                         .getId()
                         .equals(socialWorker.getAssociation().getId())) {
             throw new PostBoardException(POST_BOARD_NOT_READABLE);
+        }
+    }
+
+    private void validatePostBoardHasPost(PostBoard board, Post post) {
+        if (!post.getBoard().equals(board)) {
+            throw new PostException(POST_NOT_FOUND_IN_BOARD);
         }
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
@@ -2,6 +2,7 @@ package com.becareful.becarefulserver.domain.community.service;
 
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.*;
 
+import com.becareful.becarefulserver.domain.community.domain.BoardType;
 import com.becareful.becarefulserver.domain.community.domain.Post;
 import com.becareful.becarefulserver.domain.community.domain.PostBoard;
 import com.becareful.becarefulserver.domain.community.dto.PostSimpleDto;
@@ -31,11 +32,13 @@ public class PostService {
     private final PostBoardRepository postBoardRepository;
 
     @Transactional
-    public Long createPost(Long boardId, PostCreateRequest request) {
+    public Long createPost(String boardType, PostCreateRequest request) {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
+        BoardType type = BoardType.fromUrlBoardType(boardType);
 
         PostBoard postBoard =
-                postBoardRepository.findById(boardId).orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         validateSocialWorkerRankWritable(currentMember, postBoard);
 
@@ -46,11 +49,13 @@ public class PostService {
     }
 
     @Transactional
-    public void updatePost(Long boardId, Long postId, PostUpdateRequest request) {
+    public void updatePost(String boardType, Long postId, PostUpdateRequest request) {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
+        BoardType type = BoardType.fromUrlBoardType(boardType);
 
         PostBoard postBoard =
-                postBoardRepository.findById(boardId).orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
 
@@ -61,11 +66,13 @@ public class PostService {
     }
 
     @Transactional
-    public void deletePost(Long boardId, Long postId) {
+    public void deletePost(String boardType, Long postId) {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
+        BoardType type = BoardType.fromUrlBoardType(boardType);
 
         PostBoard postBoard =
-                postBoardRepository.findById(boardId).orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
 
@@ -76,10 +83,13 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostSimpleDto> getPosts(Long boardId, Pageable pageable) {
+    public List<PostSimpleDto> getPosts(String boardType, Pageable pageable) {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
+        BoardType type = BoardType.fromUrlBoardType(boardType);
+
         PostBoard postBoard =
-                postBoardRepository.findById(boardId).orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         validateSocialWorkerRankReadable(currentMember, postBoard);
 
@@ -100,10 +110,13 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostDetailResponse getPost(Long boardId, Long postId) {
+    public PostDetailResponse getPost(String boardType, Long postId) {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
+        BoardType type = BoardType.fromUrlBoardType(boardType);
+
         PostBoard postBoard =
-                postBoardRepository.findById(boardId).orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         validateSocialWorkerRankReadable(currentMember, postBoard);
 

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
@@ -120,8 +120,7 @@ public class PostService {
 
         validateSocialWorkerRankReadable(currentMember, postBoard);
 
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new PostException(POST_NOT_FOUND));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
 
         validatePostBoardHasPost(postBoard, post);
 

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
@@ -127,13 +127,13 @@ public class PostService {
     }
 
     private void validateSocialWorkerRankWritable(SocialWorker socialworker, PostBoard board) {
-        if (!board.getWritableRank().equals(socialworker.getAssociationRank())) {
+        if (!board.getWritableRank().equals(socialworker.getAssociationRank()) || !board.getAssociation().getId().equals(socialworker.getAssociation().getId())) {
             throw new PostBoardException(POST_BOARD_NOT_WRITABLE);
         }
     }
 
     private void validateSocialWorkerRankReadable(SocialWorker socialWorker, PostBoard board) {
-        if (!board.getReadableRank().equals(socialWorker.getAssociationRank())) {
+        if (!board.getReadableRank().equals(socialWorker.getAssociationRank()) || !board.getAssociation().getId().equals(socialWorker.getAssociation().getId())) {
             throw new PostBoardException(POST_BOARD_NOT_READABLE);
         }
     }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
@@ -36,9 +36,9 @@ public class PostService {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 
-        PostBoard postBoard =
-                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
-                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        PostBoard postBoard = postBoardRepository
+                .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         validateSocialWorkerRankWritable(currentMember, postBoard);
 
@@ -53,9 +53,9 @@ public class PostService {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 
-        PostBoard postBoard =
-                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
-                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        PostBoard postBoard = postBoardRepository
+                .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
 
@@ -70,9 +70,9 @@ public class PostService {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 
-        PostBoard postBoard =
-                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
-                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        PostBoard postBoard = postBoardRepository
+                .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
 
@@ -87,9 +87,9 @@ public class PostService {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 
-        PostBoard postBoard =
-                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
-                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        PostBoard postBoard = postBoardRepository
+                .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         validateSocialWorkerRankReadable(currentMember, postBoard);
 
@@ -114,9 +114,9 @@ public class PostService {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 
-        PostBoard postBoard =
-                postBoardRepository.findByBoardTypeAndAssociation(type, currentMember.getAssociation())
-                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        PostBoard postBoard = postBoardRepository
+                .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
 
         validateSocialWorkerRankReadable(currentMember, postBoard);
 
@@ -127,13 +127,19 @@ public class PostService {
     }
 
     private void validateSocialWorkerRankWritable(SocialWorker socialworker, PostBoard board) {
-        if (!board.getWritableRank().equals(socialworker.getAssociationRank()) || !board.getAssociation().getId().equals(socialworker.getAssociation().getId())) {
+        if (!board.getWritableRank().equals(socialworker.getAssociationRank())
+                || !board.getAssociation()
+                        .getId()
+                        .equals(socialworker.getAssociation().getId())) {
             throw new PostBoardException(POST_BOARD_NOT_WRITABLE);
         }
     }
 
     private void validateSocialWorkerRankReadable(SocialWorker socialWorker, PostBoard board) {
-        if (!board.getReadableRank().equals(socialWorker.getAssociationRank()) || !board.getAssociation().getId().equals(socialWorker.getAssociation().getId())) {
+        if (!board.getReadableRank().equals(socialWorker.getAssociationRank())
+                || !board.getAssociation()
+                        .getId()
+                        .equals(socialWorker.getAssociation().getId())) {
             throw new PostBoardException(POST_BOARD_NOT_READABLE);
         }
     }

--- a/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
@@ -48,4 +48,5 @@ public class ErrorMessage {
     public static final String POST_NOT_FOUND = "게시글이 존재하지 않습니다.";
     public static final String POST_NOT_UPDATABLE = "글 작성자만 수정할 수 있습니다.";
     public static final String POST_DIFFERENT_POST_BOARD = "URL로 넘긴 board id 에 post가 없습니다.";
+    public static final String POST_NOT_FOUND_IN_BOARD = "게시판에 해당 ID의 포스트가 존재하지 않습니다.";
 }

--- a/src/test/java/com/becareful/becarefulserver/community/domain/BoardTypeTest.java
+++ b/src/test/java/com/becareful/becarefulserver/community/domain/BoardTypeTest.java
@@ -1,9 +1,10 @@
 package com.becareful.becarefulserver.community.domain;
 
-import com.becareful.becarefulserver.domain.community.domain.BoardType;
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.becareful.becarefulserver.domain.community.domain.BoardType;
+import org.junit.jupiter.api.Test;
 
 public class BoardTypeTest {
 

--- a/src/test/java/com/becareful/becarefulserver/community/domain/BoardTypeTest.java
+++ b/src/test/java/com/becareful/becarefulserver/community/domain/BoardTypeTest.java
@@ -1,0 +1,18 @@
+package com.becareful.becarefulserver.community.domain;
+
+import com.becareful.becarefulserver.domain.community.domain.BoardType;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class BoardTypeTest {
+
+    @Test
+    public void url에_작성된_board_type을_enum타입_형식으로_변환에_성공한다() {
+        assertEquals(BoardType.ASSOCIATION_NOTICE, BoardType.fromUrlBoardType("association-notice"));
+        assertEquals(BoardType.SERVICE_NOTICE, BoardType.fromUrlBoardType("service-notice"));
+        assertEquals(BoardType.INFORMATION_SHARING, BoardType.fromUrlBoardType("information-sharing"));
+        assertEquals(BoardType.PARTICIPATION_APPLICATION, BoardType.fromUrlBoardType("participation-application"));
+        assertNull(BoardType.fromUrlBoardType("invalid-board-type"));
+    }
+}

--- a/src/test/java/com/becareful/becarefulserver/fixture/PostBoardFixture.java
+++ b/src/test/java/com/becareful/becarefulserver/fixture/PostBoardFixture.java
@@ -1,9 +1,10 @@
 package com.becareful.becarefulserver.fixture;
 
+import com.becareful.becarefulserver.domain.community.domain.BoardType;
 import com.becareful.becarefulserver.domain.community.domain.PostBoard;
 import com.becareful.becarefulserver.domain.socialworker.domain.vo.AssociationRank;
 
 public class PostBoardFixture {
 
-    public static final PostBoard 협회공지 = PostBoard.create("협회공지", AssociationRank.MEMBER, AssociationRank.MEMBER);
+    public static final PostBoard 협회공지 = PostBoard.create(BoardType.ASSOCIATION_NOTICE, AssociationRank.MEMBER, AssociationRank.MEMBER, AssociationFixture.JEONJU_ASSOCIATION);
 }

--- a/src/test/java/com/becareful/becarefulserver/fixture/PostBoardFixture.java
+++ b/src/test/java/com/becareful/becarefulserver/fixture/PostBoardFixture.java
@@ -6,5 +6,9 @@ import com.becareful.becarefulserver.domain.socialworker.domain.vo.AssociationRa
 
 public class PostBoardFixture {
 
-    public static final PostBoard 협회공지 = PostBoard.create(BoardType.ASSOCIATION_NOTICE, AssociationRank.MEMBER, AssociationRank.MEMBER, AssociationFixture.JEONJU_ASSOCIATION);
+    public static final PostBoard 협회공지 = PostBoard.create(
+            BoardType.ASSOCIATION_NOTICE,
+            AssociationRank.MEMBER,
+            AssociationRank.MEMBER,
+            AssociationFixture.JEONJU_ASSOCIATION);
 }


### PR DESCRIPTION
close #141 

게시판 엔티티에서 board name 대신에 Board Type 추가하고, api 호출할 때 board id 대신 board type 으로 url 명시하도록 변경했습니다.
board_id 를 프론트에게 알려주는 것보다 Board Type 으로 관리하는 게 더 간편할 것 같더라구요