### PR TITLE
feat: 게시글 이미지 / 비디오 업로드 로직 구현

### DIFF
--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/Post.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/Post.java
@@ -7,6 +7,8 @@ import com.becareful.becarefulserver.domain.common.domain.BaseEntity;
 import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
 import com.becareful.becarefulserver.global.exception.exception.PostException;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +40,9 @@ public class Post extends BaseEntity {
     @JoinColumn(name = "social_worker_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private SocialWorker author;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PostMedia> mediaList = new ArrayList<>();
 
     @Builder
     private Post(String title, String content, boolean isImportant, PostBoard board, SocialWorker author) {
@@ -81,5 +86,24 @@ public class Post extends BaseEntity {
         if (!this.board.getId().equals(boardId)) {
             throw new PostException(POST_DIFFERENT_POST_BOARD);
         }
+    }
+
+    /**
+     * 미디어 추가 로직
+     */
+    public void addMedia(PostMedia media) {
+        this.mediaList.add(media);
+    }
+
+    public List<PostMedia> getImageMediaList() {
+        return this.mediaList.stream()
+                .filter(media -> media.getFileType() == FileType.IMAGE)
+                .toList();
+    }
+
+    public List<PostMedia> getVideoMediaList() {
+        return this.mediaList.stream()
+                .filter(media -> media.getFileType() == FileType.VIDEO)
+                .toList();
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/PostMedia.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/PostMedia.java
@@ -1,0 +1,70 @@
+package com.becareful.becarefulserver.domain.community.domain;
+
+import com.becareful.becarefulserver.domain.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostMedia extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_media_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Column(nullable = false)
+    private String mediaUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FileType fileType;
+
+    private Long fileSize;
+
+    private Integer videoDuration;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private PostMedia(
+            String fileName, String mediaUrl, FileType fileType, Long fileSize, Integer videoDuration, Post post) {
+        this.fileName = fileName;
+        this.mediaUrl = mediaUrl;
+        this.fileType = fileType;
+        this.fileSize = fileSize;
+        this.videoDuration = videoDuration;
+        this.post = post;
+    }
+
+    public static PostMedia createImage(String fileName, String mediaUrl, Long fileSize, Post post) {
+        return PostMedia.builder()
+                .fileName(fileName)
+                .mediaUrl(mediaUrl)
+                .fileType(FileType.IMAGE)
+                .fileSize(fileSize)
+                .post(post)
+                .build();
+    }
+
+    public static PostMedia createVideo(
+            String fileName, String mediaUrl, Long fileSize, Integer videoDuration, Post post) {
+        return PostMedia.builder()
+                .fileName(fileName)
+                .mediaUrl(mediaUrl)
+                .fileType(FileType.VIDEO)
+                .fileSize(fileSize)
+                .videoDuration(videoDuration)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/MediaInfoDto.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/MediaInfoDto.java
@@ -1,0 +1,10 @@
+package com.becareful.becarefulserver.domain.community.dto;
+
+import com.becareful.becarefulserver.domain.community.domain.FileType;
+import org.springframework.web.multipart.MultipartFile;
+
+public record MediaInfoDto(String fileName, String mediaUrl, FileType fileType, Long fileSize, Integer videoDuration) {
+    public static MediaInfoDto of(String mediaUrl, MultipartFile file, FileType fileType, Integer videoDuration) {
+        return new MediaInfoDto(file.getOriginalFilename(), mediaUrl, fileType, file.getSize(), videoDuration);
+    }
+}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/PostMediaDto.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/PostMediaDto.java
@@ -1,0 +1,17 @@
+package com.becareful.becarefulserver.domain.community.dto;
+
+import com.becareful.becarefulserver.domain.community.domain.FileType;
+import com.becareful.becarefulserver.domain.community.domain.PostMedia;
+
+public record PostMediaDto(
+        Long id, String fileName, String mediaUrl, FileType fileType, Long fileSize, Integer videoDuration) {
+    public static PostMediaDto from(PostMedia postMedia) {
+        return new PostMediaDto(
+                postMedia.getId(),
+                postMedia.getFileName(),
+                postMedia.getMediaUrl(),
+                postMedia.getFileType(),
+                postMedia.getFileSize(),
+                postMedia.getVideoDuration());
+    }
+}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/PostCreateOrUpdateRequest.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/PostCreateOrUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.becareful.becarefulserver.domain.community.dto.request;
+
+import com.becareful.becarefulserver.domain.community.dto.MediaInfoDto;
+import jakarta.validation.constraints.NotBlank;
+import java.util.List;
+
+public record PostCreateOrUpdateRequest(
+        @NotBlank(message = "글 제목은 필수 입니다.") String title,
+        String content,
+        boolean isImportant,
+        List<MediaInfoDto> imageList,
+        List<MediaInfoDto> videoList) {}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/PostCreateRequest.java
@@ -1,6 +1,0 @@
-package com.becareful.becarefulserver.domain.community.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record PostCreateRequest(
-        @NotBlank(message = "글 제목은 필수 입니다.") String title, String content, boolean isImportant) {}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/PostUpdateRequest.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/PostUpdateRequest.java
@@ -1,3 +1,0 @@
-package com.becareful.becarefulserver.domain.community.dto.request;
-
-public record PostUpdateRequest(String title, String content, boolean isImportant) {}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/response/PostDetailResponse.java
@@ -2,7 +2,9 @@ package com.becareful.becarefulserver.domain.community.dto.response;
 
 import com.becareful.becarefulserver.domain.community.domain.Post;
 import com.becareful.becarefulserver.domain.community.dto.AuthorSimpleDto;
+import com.becareful.becarefulserver.domain.community.dto.PostMediaDto;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 public record PostDetailResponse(
         Long postId,
@@ -11,7 +13,9 @@ public record PostDetailResponse(
         boolean isImportant,
         boolean isEdited,
         String postedDate,
-        AuthorSimpleDto author) {
+        AuthorSimpleDto author,
+        List<PostMediaDto> images,
+        List<PostMediaDto> videos) {
     public static PostDetailResponse from(Post post) {
         return new PostDetailResponse(
                 post.getId(),
@@ -20,6 +24,8 @@ public record PostDetailResponse(
                 post.isImportant(),
                 !post.getCreateDate().isEqual(post.getUpdateDate()),
                 post.getUpdateDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
-                AuthorSimpleDto.from(post.getAuthor()));
+                AuthorSimpleDto.from(post.getAuthor()),
+                post.getImageMediaList().stream().map(PostMediaDto::from).toList(),
+                post.getVideoMediaList().stream().map(PostMediaDto::from).toList());
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/response/PostDetailResponse.java
@@ -1,8 +1,8 @@
 package com.becareful.becarefulserver.domain.community.dto.response;
 
 import com.becareful.becarefulserver.domain.community.domain.Post;
+import com.becareful.becarefulserver.domain.community.domain.PostMedia;
 import com.becareful.becarefulserver.domain.community.dto.AuthorSimpleDto;
-import com.becareful.becarefulserver.domain.community.dto.PostMediaDto;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
@@ -14,8 +14,8 @@ public record PostDetailResponse(
         boolean isEdited,
         String postedDate,
         AuthorSimpleDto author,
-        List<PostMediaDto> images,
-        List<PostMediaDto> videos) {
+        List<String> imageUrls,
+        List<String> videoUrls) {
     public static PostDetailResponse from(Post post) {
         return new PostDetailResponse(
                 post.getId(),
@@ -25,7 +25,7 @@ public record PostDetailResponse(
                 !post.getCreateDate().isEqual(post.getUpdateDate()),
                 post.getUpdateDate().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
                 AuthorSimpleDto.from(post.getAuthor()),
-                post.getImageMediaList().stream().map(PostMediaDto::from).toList(),
-                post.getVideoMediaList().stream().map(PostMediaDto::from).toList());
+                post.getImageMediaList().stream().map(PostMedia::getMediaUrl).toList(),
+                post.getVideoMediaList().stream().map(PostMedia::getMediaUrl).toList());
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/repository/PostMediaRepository.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/repository/PostMediaRepository.java
@@ -1,0 +1,8 @@
+package com.becareful.becarefulserver.domain.community.repository;
+
+import com.becareful.becarefulserver.domain.community.domain.PostMedia;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PostMediaRepository extends JpaRepository<PostMedia, Long> {}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/PostMediaService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/PostMediaService.java
@@ -1,0 +1,80 @@
+package com.becareful.becarefulserver.domain.community.service;
+
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.*;
+
+import com.becareful.becarefulserver.domain.community.domain.FileType;
+import com.becareful.becarefulserver.domain.community.dto.MediaInfoDto;
+import com.becareful.becarefulserver.global.exception.exception.PostException;
+import com.becareful.becarefulserver.global.util.FileUtil;
+import java.io.IOException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PostMediaService {
+
+    private final FileUtil fileUtil;
+    private static final long MAX_IMAGE_SIZE = 30 * 1024 * 1024; // 30MB
+    private static final long MAX_VIDEO_SIZE = 1024 * 1024 * 1024; // 1GB
+    private static final int MAX_VIDEO_DURATION = 15 * 60; // 15분(초 단위)
+
+    @Transactional
+    public MediaInfoDto uploadPostMedia(MultipartFile file, FileType fileType, Integer videoDuration) {
+        try {
+            validateFileSize(file, fileType);
+            if (fileType == FileType.VIDEO) {
+                validateVideoDuration(videoDuration);
+            }
+
+            String fileName = generateFileName(file);
+            String mediaUrl = fileUtil.upload(file, getDirectoryByFileType(fileType), fileName);
+
+            return MediaInfoDto.of(mediaUrl, file, fileType, videoDuration);
+        } catch (IOException e) {
+            throw new PostException(POST_MEDIA_UPLOAD_FAILED);
+        }
+    }
+
+    private void validateFileSize(MultipartFile file, FileType fileType) {
+        if (fileType == FileType.IMAGE && file.getSize() <= MAX_IMAGE_SIZE) {
+            return;
+        }
+        if (fileType == FileType.VIDEO && file.getSize() <= MAX_VIDEO_SIZE) {
+            return;
+        }
+
+        throw new PostException(POST_MEDIA_VALIDATION_FAILED);
+    }
+
+    private void validateVideoDuration(Integer videoDuration) {
+        if (videoDuration == null || videoDuration > MAX_VIDEO_DURATION) {
+            throw new PostException(POST_MEDIA_VALIDATION_FAILED);
+        }
+    }
+
+    private String getDirectoryByFileType(FileType fileType) {
+        // TODO : 디렉토리 경로 상수화
+        if (fileType == FileType.IMAGE) {
+            return "post-images";
+        }
+        return "post-videos";
+    }
+
+    private String generateFileName(MultipartFile file) {
+        return UUID.randomUUID() + getExtension(file);
+    }
+
+    private String getExtension(MultipartFile file) {
+        String fileName = file.getOriginalFilename();
+        if (fileName == null) {
+            throw new PostException(POST_MEDIA_FILE_HAS_NO_NAME);
+        }
+        return fileName.substring(fileName.lastIndexOf("."));
+    }
+}

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/PostService.java
@@ -6,8 +6,7 @@ import com.becareful.becarefulserver.domain.community.domain.BoardType;
 import com.becareful.becarefulserver.domain.community.domain.Post;
 import com.becareful.becarefulserver.domain.community.domain.PostBoard;
 import com.becareful.becarefulserver.domain.community.dto.PostSimpleDto;
-import com.becareful.becarefulserver.domain.community.dto.request.PostCreateRequest;
-import com.becareful.becarefulserver.domain.community.dto.request.PostUpdateRequest;
+import com.becareful.becarefulserver.domain.community.dto.request.PostCreateOrUpdateRequest;
 import com.becareful.becarefulserver.domain.community.dto.response.PostDetailResponse;
 import com.becareful.becarefulserver.domain.community.repository.PostBoardRepository;
 import com.becareful.becarefulserver.domain.community.repository.PostRepository;
@@ -31,8 +30,11 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostBoardRepository postBoardRepository;
 
+    private static final int MAX_IMAGE_COUNT = 100;
+    private static final int MAX_VIDEO_COUNT = 3;
+
     @Transactional
-    public Long createPost(String boardType, PostCreateRequest request) {
+    public Long createPost(String boardType, PostCreateOrUpdateRequest request) {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 
@@ -49,7 +51,7 @@ public class PostService {
     }
 
     @Transactional
-    public void updatePost(String boardType, Long postId, PostUpdateRequest request) {
+    public void updatePost(String boardType, Long postId, PostCreateOrUpdateRequest request) {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 

--- a/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
@@ -50,4 +50,8 @@ public class ErrorMessage {
     public static final String POST_NOT_UPDATABLE = "글 작성자만 수정할 수 있습니다.";
     public static final String POST_DIFFERENT_POST_BOARD = "URL로 넘긴 board id 에 post가 없습니다.";
     public static final String POST_NOT_FOUND_IN_BOARD = "게시판에 해당 ID의 포스트가 존재하지 않습니다.";
+
+    public static final String POST_MEDIA_FILE_HAS_NO_NAME = "미디어 파일의 이름이 없습니다.";
+    public static final String POST_MEDIA_VALIDATION_FAILED = "미디어 파일 검증에 실패했습니다.";
+    public static final String POST_MEDIA_UPLOAD_FAILED = "미디어 파일 업로드에 실패했습니다.";
 }

--- a/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
@@ -54,4 +54,6 @@ public class ErrorMessage {
     public static final String POST_MEDIA_FILE_HAS_NO_NAME = "미디어 파일의 이름이 없습니다.";
     public static final String POST_MEDIA_VALIDATION_FAILED = "미디어 파일 검증에 실패했습니다.";
     public static final String POST_MEDIA_UPLOAD_FAILED = "미디어 파일 업로드에 실패했습니다.";
+    public static final String POST_MEDIA_IMAGE_COUNT_EXCEEDED = "이미지는 최대 100개까지 업로드할 수 있습니다.";
+    public static final String POST_MEDIA_VIDEO_COUNT_EXCEEDED = "동영상은 최대 3개까지 업로드할 수 있습니다.";
 }

--- a/src/main/java/com/becareful/becarefulserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/GlobalExceptionHandler.java
@@ -36,7 +36,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleUnknownException(Exception e) {
-        log.error("Unknown exception: {}", e.getMessage());
+        log.error("Unknown exception: {} {}", e.getMessage(), e);
         return ResponseEntity.internalServerError().body(new ErrorResponse(e.getMessage()));
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/global/util/FileUtil.java
+++ b/src/main/java/com/becareful/becarefulserver/global/util/FileUtil.java
@@ -17,13 +17,13 @@ public class FileUtil {
     private static final String baseUrl = "https://becareful-s3.s3.ap-northeast-2.amazonaws.com/";
 
     public String upload(MultipartFile file, String directory, String fileName) throws IOException {
-
         String key = directory + "/" + fileName;
+
         ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentType(file.getContentType());
         metadata.setContentLength(file.getSize());
 
         amazonS3Client.putObject(bucket, key, file.getInputStream(), metadata);
-        return baseUrl + fileName;
+        return baseUrl + key;
     }
 }


### PR DESCRIPTION
- 게시글 작성시 이미지, 비디오를 먼저 업로드하고 url 을 받습니다.
  프론트는 받은 url 을 포함한 미디어 데이터 정보를 게시글 작성/수정시 함께 넘깁니다.

- 게시글 수정시, 기존 이미지, 비디오 url 도 모두 입력해서 넘겨야 합니다.

- 게시글 삭제시, 연관된 이미지/비디오 데이터도 삭제됩니다. (S3 에서는 아직 삭제되지 않습니다.)

close #115 