### PR TITLE
feat: 커뮤니티 댓글 수정 & 삭제 API

### DIFF
--- a/src/main/java/com/becareful/becarefulserver/domain/community/controller/CommentController.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/controller/CommentController.java
@@ -52,9 +52,7 @@ public class CommentController {
     @Operation(summary = "댓글 삭제")
     @DeleteMapping("/{commentId}")
     public ResponseEntity<Void> deleteComment(
-            @PathVariable String boardType,
-            @PathVariable Long postId,
-            @PathVariable Long commentId) {
+            @PathVariable String boardType, @PathVariable Long postId, @PathVariable Long commentId) {
         commentService.deleteComment(boardType, postId, commentId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/controller/CommentController.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/controller/CommentController.java
@@ -1,6 +1,7 @@
 package com.becareful.becarefulserver.domain.community.controller;
 
 import com.becareful.becarefulserver.domain.community.dto.request.CommentCreateRequest;
+import com.becareful.becarefulserver.domain.community.dto.request.CommentUpdateRequest;
 import com.becareful.becarefulserver.domain.community.dto.response.CommentResponse;
 import com.becareful.becarefulserver.domain.community.service.CommentService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -37,5 +38,24 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
-    // TODO : 댓글 수정 / 삭제
+    @Operation(summary = "댓글 수정")
+    @PutMapping("/{commentId}")
+    public ResponseEntity<Void> updateComment(
+            @PathVariable String boardType,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @RequestBody CommentUpdateRequest request) {
+        commentService.updateComment(boardType, postId, commentId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "댓글 삭제")
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable String boardType,
+            @PathVariable Long postId,
+            @PathVariable Long commentId) {
+        commentService.deleteComment(boardType, postId, commentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/BoardType.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/BoardType.java
@@ -1,15 +1,11 @@
 package com.becareful.becarefulserver.domain.community.domain;
 
 public enum BoardType {
-    /**
-     * ASSOCIATION = 협회 (각 기관장이 속한 협회)
-     * INSTITUTION = 기관 (사회복지사가 소속된 기관)
-     * SERVICE = 공단 (건강보험공단)
-     **/
-    ASSOCIATION_NOTICE,
-    SERVICE_NOTICE,
-    INFORMATION_SHARING,
-    PARTICIPATION_APPLICATION;
+    /** 게시판 종류 */
+    ASSOCIATION_NOTICE, // 협회 공지 게시판
+    SERVICE_NOTICE, // 공단 공지 게시판
+    INFORMATION_SHARING, // 정보 공유 게시판
+    PARTICIPATION_APPLICATION; // 행사/신청 게시판
 
     public static BoardType fromUrlBoardType(String boardType) {
         boardType = convertUrlBoardTypeToName(boardType);

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/BoardType.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/BoardType.java
@@ -1,11 +1,15 @@
 package com.becareful.becarefulserver.domain.community.domain;
 
 public enum BoardType {
-    /** 게시판 종류 */
-    ASSOCIATION_NOTICE, // 협회 공지 게시판
-    SERVICE_NOTICE, // 공단 공지 게시판
-    INFORMATION_SHARING, // 정보 공유 게시판
-    PARTICIPATION_APPLICATION; // 행사/신청 게시판
+    /**
+     * ASSOCIATION = 협회 (각 기관장이 속한 협회)
+     * INSTITUTION = 기관 (사회복지사가 소속된 기관)
+     * SERVICE = 공단 (건강보험공단)
+     **/
+    ASSOCIATION_NOTICE,
+    SERVICE_NOTICE,
+    INFORMATION_SHARING,
+    PARTICIPATION_APPLICATION;
 
     public static BoardType fromUrlBoardType(String boardType) {
         boardType = convertUrlBoardTypeToName(boardType);

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/Comment.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/Comment.java
@@ -1,9 +1,11 @@
 package com.becareful.becarefulserver.domain.community.domain;
 
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.COMMENT_NOT_FOUND;
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.COMMENT_NOT_UPDATABLE;
+
 import com.becareful.becarefulserver.domain.common.domain.BaseEntity;
 import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
 import com.becareful.becarefulserver.global.exception.exception.CommentException;
-import static com.becareful.becarefulserver.global.exception.ErrorMessage.COMMENT_NOT_UPDATABLE;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -49,6 +51,12 @@ public class Comment extends BaseEntity {
     public void validateAuthor(SocialWorker currentMember) {
         if (!this.author.getId().equals(currentMember.getId())) {
             throw new CommentException(COMMENT_NOT_UPDATABLE);
+        }
+    }
+
+    public void validatePost(Post post) {
+        if (!this.post.getId().equals(post.getId())) {
+            throw new CommentException(COMMENT_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/domain/Comment.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/domain/Comment.java
@@ -2,6 +2,8 @@ package com.becareful.becarefulserver.domain.community.domain;
 
 import com.becareful.becarefulserver.domain.common.domain.BaseEntity;
 import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
+import com.becareful.becarefulserver.global.exception.exception.CommentException;
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.COMMENT_NOT_UPDATABLE;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,5 +40,15 @@ public class Comment extends BaseEntity {
 
     public static Comment create(String content, SocialWorker author, Post post) {
         return Comment.builder().content(content).author(author).post(post).build();
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
+
+    public void validateAuthor(SocialWorker currentMember) {
+        if (!this.author.getId().equals(currentMember.getId())) {
+            throw new CommentException(COMMENT_NOT_UPDATABLE);
+        }
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.becareful.becarefulserver.domain.community.dto.request;
+
+/**
+ * Request payload for updating a comment.
+ */
+public record CommentUpdateRequest(String content) {}
+

--- a/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/dto/request/CommentUpdateRequest.java
@@ -4,4 +4,3 @@ package com.becareful.becarefulserver.domain.community.dto.request;
  * Request payload for updating a comment.
  */
 public record CommentUpdateRequest(String content) {}
-

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/CommentService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/CommentService.java
@@ -2,12 +2,14 @@ package com.becareful.becarefulserver.domain.community.service;
 
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.POST_BOARD_NOT_FOUND;
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.POST_NOT_FOUND;
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.COMMENT_NOT_FOUND;
 
 import com.becareful.becarefulserver.domain.community.domain.BoardType;
 import com.becareful.becarefulserver.domain.community.domain.Comment;
 import com.becareful.becarefulserver.domain.community.domain.Post;
 import com.becareful.becarefulserver.domain.community.domain.PostBoard;
 import com.becareful.becarefulserver.domain.community.dto.request.CommentCreateRequest;
+import com.becareful.becarefulserver.domain.community.dto.request.CommentUpdateRequest;
 import com.becareful.becarefulserver.domain.community.dto.response.CommentResponse;
 import com.becareful.becarefulserver.domain.community.repository.CommentRepository;
 import com.becareful.becarefulserver.domain.community.repository.PostBoardRepository;
@@ -15,6 +17,7 @@ import com.becareful.becarefulserver.domain.community.repository.PostRepository;
 import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
 import com.becareful.becarefulserver.global.exception.exception.PostBoardException;
 import com.becareful.becarefulserver.global.exception.exception.PostException;
+import com.becareful.becarefulserver.global.exception.exception.CommentException;
 import com.becareful.becarefulserver.global.util.AuthUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -64,5 +67,47 @@ public class CommentService {
         return commentRepository.findAllByPost(post).stream()
                 .map(CommentResponse::from)
                 .toList();
+    }
+
+    @Transactional
+    public void updateComment(String boardType, Long postId, Long commentId, CommentUpdateRequest request) {
+        SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
+        BoardType type = BoardType.fromUrlBoardType(boardType);
+
+        PostBoard postBoard =
+                postBoardRepository
+                        .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentException(COMMENT_NOT_FOUND));
+
+        postBoard.validateReadableFor(currentMember);
+        post.validateBoard(postBoard.getId());
+        if (!comment.getPost().getId().equals(post.getId())) {
+            throw new CommentException(COMMENT_NOT_FOUND);
+        }
+        comment.validateAuthor(currentMember);
+        comment.update(request.content());
+    }
+
+    @Transactional
+    public void deleteComment(String boardType, Long postId, Long commentId) {
+        SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
+        BoardType type = BoardType.fromUrlBoardType(boardType);
+
+        PostBoard postBoard =
+                postBoardRepository
+                        .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
+        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentException(COMMENT_NOT_FOUND));
+
+        postBoard.validateReadableFor(currentMember);
+        post.validateBoard(postBoard.getId());
+        if (!comment.getPost().getId().equals(post.getId())) {
+            throw new CommentException(COMMENT_NOT_FOUND);
+        }
+        comment.validateAuthor(currentMember);
+        commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/becareful/becarefulserver/domain/community/service/CommentService.java
+++ b/src/main/java/com/becareful/becarefulserver/domain/community/service/CommentService.java
@@ -1,8 +1,8 @@
 package com.becareful.becarefulserver.domain.community.service;
 
+import static com.becareful.becarefulserver.global.exception.ErrorMessage.COMMENT_NOT_FOUND;
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.POST_BOARD_NOT_FOUND;
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.POST_NOT_FOUND;
-import static com.becareful.becarefulserver.global.exception.ErrorMessage.COMMENT_NOT_FOUND;
 
 import com.becareful.becarefulserver.domain.community.domain.BoardType;
 import com.becareful.becarefulserver.domain.community.domain.Comment;
@@ -15,9 +15,9 @@ import com.becareful.becarefulserver.domain.community.repository.CommentReposito
 import com.becareful.becarefulserver.domain.community.repository.PostBoardRepository;
 import com.becareful.becarefulserver.domain.community.repository.PostRepository;
 import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
+import com.becareful.becarefulserver.global.exception.exception.CommentException;
 import com.becareful.becarefulserver.global.exception.exception.PostBoardException;
 import com.becareful.becarefulserver.global.exception.exception.PostException;
-import com.becareful.becarefulserver.global.exception.exception.CommentException;
 import com.becareful.becarefulserver.global.util.AuthUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -74,18 +74,16 @@ public class CommentService {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 
-        PostBoard postBoard =
-                postBoardRepository
-                        .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
-                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        PostBoard postBoard = postBoardRepository
+                .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentException(COMMENT_NOT_FOUND));
+        Comment comment =
+                commentRepository.findById(commentId).orElseThrow(() -> new CommentException(COMMENT_NOT_FOUND));
 
         postBoard.validateReadableFor(currentMember);
         post.validateBoard(postBoard.getId());
-        if (!comment.getPost().getId().equals(post.getId())) {
-            throw new CommentException(COMMENT_NOT_FOUND);
-        }
+        comment.validatePost(post);
         comment.validateAuthor(currentMember);
         comment.update(request.content());
     }
@@ -95,18 +93,16 @@ public class CommentService {
         SocialWorker currentMember = authUtil.getLoggedInSocialWorker();
         BoardType type = BoardType.fromUrlBoardType(boardType);
 
-        PostBoard postBoard =
-                postBoardRepository
-                        .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
-                        .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
+        PostBoard postBoard = postBoardRepository
+                .findByBoardTypeAndAssociation(type, currentMember.getAssociation())
+                .orElseThrow(() -> new PostBoardException(POST_BOARD_NOT_FOUND));
         Post post = postRepository.findById(postId).orElseThrow(() -> new PostException(POST_NOT_FOUND));
-        Comment comment = commentRepository.findById(commentId).orElseThrow(() -> new CommentException(COMMENT_NOT_FOUND));
+        Comment comment =
+                commentRepository.findById(commentId).orElseThrow(() -> new CommentException(COMMENT_NOT_FOUND));
 
         postBoard.validateReadableFor(currentMember);
         post.validateBoard(postBoard.getId());
-        if (!comment.getPost().getId().equals(post.getId())) {
-            throw new CommentException(COMMENT_NOT_FOUND);
-        }
+        comment.validatePost(post);
         comment.validateAuthor(currentMember);
         commentRepository.delete(comment);
     }

--- a/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
@@ -54,6 +54,8 @@ public class ErrorMessage {
     public static final String POST_NOT_UPDATABLE = "글 작성자만 수정할 수 있습니다.";
     public static final String POST_DIFFERENT_POST_BOARD = "URL로 넘긴 board id 에 post가 없습니다.";
     public static final String POST_NOT_FOUND_IN_BOARD = "게시판에 해당 ID의 포스트가 존재하지 않습니다.";
+    public static final String COMMENT_NOT_FOUND = "댓글이 존재하지 않습니다.";
+    public static final String COMMENT_NOT_UPDATABLE = "댓글 작성자만 수정할 수 있습니다.";
 
     public static final String POST_MEDIA_FILE_HAS_NO_NAME = "미디어 파일의 이름이 없습니다.";
     public static final String POST_MEDIA_VALIDATION_FAILED = "미디어 파일 검증에 실패했습니다.";

--- a/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/ErrorMessage.java
@@ -18,7 +18,7 @@ public class ErrorMessage {
     public static final String INVALID_TOKEN_FORMAT = "엑세스 토큰 형식이 유효하지 않습니다.";
     public static final String INVALID_TOKEN = "엑세스 토큰이 유효하지 않습니다.";
     public static final String TOKEN_NOT_CONTAINED = "요청에 토큰이 포함되지 않았습니다.";
-    public static String INVALID_REFRESH_TOKEN = "리프레시 토튼이 유효하지 않습니다.";
+    public static String INVALID_REFRESH_TOKEN = "리프레시 토큰이 유효하지 않습니다.";
 
     public static final String SOCIALWORKER_REQUIRED_AGREEMENT = "필수 약관에 동의해야 합니다.";
     public static final String SOCIALWORKER_ALREADY_EXISTS_PHONENUMBER = "이미 가입된 전화번호 입니다.";

--- a/src/main/java/com/becareful/becarefulserver/global/exception/exception/CommentException.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/exception/CommentException.java
@@ -1,0 +1,12 @@
+package com.becareful.becarefulserver.global.exception.exception;
+
+/**
+ * Raised when comment related business rules are violated.
+ */
+public class CommentException extends DomainException {
+
+    public CommentException(String message) {
+        super(message);
+    }
+}
+

--- a/src/main/java/com/becareful/becarefulserver/global/exception/exception/CommentException.java
+++ b/src/main/java/com/becareful/becarefulserver/global/exception/exception/CommentException.java
@@ -9,4 +9,3 @@ public class CommentException extends DomainException {
         super(message);
     }
 }
-

--- a/src/main/java/com/becareful/becarefulserver/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/becareful/becarefulserver/global/security/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.becareful.becarefulserver.global.security;
 import static com.becareful.becarefulserver.global.exception.ErrorMessage.INVALID_REFRESH_TOKEN;
 
 import com.becareful.becarefulserver.global.constant.SecurityConstant;
+import com.becareful.becarefulserver.global.exception.ErrorMessage;
 import com.becareful.becarefulserver.global.exception.exception.AuthException;
 import com.becareful.becarefulserver.global.properties.CookieProperties;
 import com.becareful.becarefulserver.global.properties.JwtProperties;
@@ -59,7 +60,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         // AccessToken이 만료되었는지 확인
         if (accessToken == null || !jwtUtil.isValid(accessToken)) {
 
-            // 리프레시 토큰도 없는 경우 에러 응답
+            // 리프레시 토큰이 존재하고 유효할 때만 재발급 시도
             if (refreshToken != null && jwtUtil.isValid(refreshToken)) {
                 // 액세스 토큰이 만료되었으면 리프레시 토큰을 사용하여 새 토큰 발급
                 accessToken = getAccessTokenFromRefresh(refreshToken);
@@ -73,6 +74,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 newAccessTokenCookie.setAttribute("SameSite", cookieProperties.getCookieSameSite());
 
                 response.addCookie(newAccessTokenCookie);
+            } else if (accessToken == null && refreshToken == null) {
+                throw new AuthException(ErrorMessage.TOKEN_NOT_CONTAINED);
             } else {
                 throw new AuthException(INVALID_REFRESH_TOKEN);
             }

--- a/src/test/java/com/becareful/becarefulserver/common/DatabaseCleaner.java
+++ b/src/test/java/com/becareful/becarefulserver/common/DatabaseCleaner.java
@@ -1,13 +1,19 @@
 package com.becareful.becarefulserver.common;
 
+import com.becareful.becarefulserver.domain.association.domain.Association;
 import com.becareful.becarefulserver.domain.association.repository.AssociationRepository;
+import com.becareful.becarefulserver.domain.common.vo.Gender;
+import com.becareful.becarefulserver.domain.nursing_institution.domain.NursingInstitution;
 import com.becareful.becarefulserver.domain.nursing_institution.repository.NursingInstitutionRepository;
+import com.becareful.becarefulserver.domain.nursing_institution.vo.InstitutionRank;
+import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
+import com.becareful.becarefulserver.domain.socialworker.domain.vo.AssociationRank;
 import com.becareful.becarefulserver.domain.socialworker.repository.SocialWorkerRepository;
-import com.becareful.becarefulserver.fixture.AssociationFixture;
 import com.becareful.becarefulserver.fixture.NursingInstitutionFixture;
 import com.becareful.becarefulserver.fixture.SocialWorkerFixture;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.time.LocalDate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,9 +24,11 @@ public class DatabaseCleaner {
     @PersistenceContext
     private EntityManager em;
 
-    @Autowired private SocialWorkerRepository socialworkerRepository;
+    @Autowired
+    private SocialWorkerRepository socialworkerRepository;
 
-    @Autowired private AssociationRepository associationRepository;
+    @Autowired
+    private AssociationRepository associationRepository;
 
     @Autowired
     private NursingInstitutionRepository institutionRepository;
@@ -28,16 +36,36 @@ public class DatabaseCleaner {
     @Transactional
     public void clean() {
         em.createNativeQuery("set foreign_key_checks = 0").executeUpdate();
-        em.getMetamodel().getEntities()
-                .forEach(
-                        entity -> {
-                            String tableName = camelToSnake(entity.getName());
-                            em.createNativeQuery("truncate table " + tableName).executeUpdate();
-                        });
+        em.getMetamodel().getEntities().forEach(entity -> {
+            String tableName = camelToSnake(entity.getName());
+            em.createNativeQuery("truncate table " + tableName).executeUpdate();
+        });
         em.createNativeQuery("set foreign_key_checks = 1").executeUpdate();
-        institutionRepository.save(NursingInstitutionFixture.NURSING_INSTITUTION);
-        associationRepository.save(AssociationFixture.JEONJU_ASSOCIATION);
+        NursingInstitutionFixture.NURSING_INSTITUTION = NursingInstitutionFixture.create();
+        NursingInstitution institution = institutionRepository.save(NursingInstitutionFixture.NURSING_INSTITUTION);
+        Association savedAssociation = associationRepository.save(Association.create("전주완주장기요양협회", "url", 2000));
+        SocialWorkerFixture.SOCIAL_WORKER_1 = SocialWorker.create(
+                "김복지",
+                "nickname",
+                LocalDate.of(2000, 5, 9),
+                Gender.FEMALE,
+                "010-1234-5678",
+                InstitutionRank.SOCIAL_WORKER,
+                AssociationRank.NONE,
+                true,
+                institution);
+        SocialWorkerFixture.SOCIAL_WORKER_MANAGER = SocialWorker.create(
+                "박복지",
+                "nickname",
+                LocalDate.of(2000, 5, 9),
+                Gender.FEMALE,
+                "010-1234-5678",
+                InstitutionRank.SOCIAL_WORKER,
+                AssociationRank.MEMBER,
+                true,
+                institution);
         socialworkerRepository.save(SocialWorkerFixture.SOCIAL_WORKER_1);
+        SocialWorkerFixture.SOCIAL_WORKER_MANAGER.joinAssociation(savedAssociation, AssociationRank.MEMBER);
         socialworkerRepository.save(SocialWorkerFixture.SOCIAL_WORKER_MANAGER);
     }
 

--- a/src/test/java/com/becareful/becarefulserver/common/DatabaseCleaner.java
+++ b/src/test/java/com/becareful/becarefulserver/common/DatabaseCleaner.java
@@ -1,7 +1,9 @@
 package com.becareful.becarefulserver.common;
 
+import com.becareful.becarefulserver.domain.association.repository.AssociationRepository;
 import com.becareful.becarefulserver.domain.nursing_institution.repository.NursingInstitutionRepository;
 import com.becareful.becarefulserver.domain.socialworker.repository.SocialWorkerRepository;
+import com.becareful.becarefulserver.fixture.AssociationFixture;
 import com.becareful.becarefulserver.fixture.NursingInstitutionFixture;
 import com.becareful.becarefulserver.fixture.SocialWorkerFixture;
 import jakarta.persistence.EntityManager;
@@ -16,8 +18,9 @@ public class DatabaseCleaner {
     @PersistenceContext
     private EntityManager em;
 
-    @Autowired
-    private SocialWorkerRepository socialworkerRepository;
+    @Autowired private SocialWorkerRepository socialworkerRepository;
+
+    @Autowired private AssociationRepository associationRepository;
 
     @Autowired
     private NursingInstitutionRepository institutionRepository;
@@ -25,12 +28,20 @@ public class DatabaseCleaner {
     @Transactional
     public void clean() {
         em.createNativeQuery("set foreign_key_checks = 0").executeUpdate();
-        em.getMetamodel().getEntities().forEach(entity -> {
-            em.createNativeQuery("truncate table " + entity.getName()).executeUpdate();
-        });
+        em.getMetamodel().getEntities()
+                .forEach(
+                        entity -> {
+                            String tableName = camelToSnake(entity.getName());
+                            em.createNativeQuery("truncate table " + tableName).executeUpdate();
+                        });
         em.createNativeQuery("set foreign_key_checks = 1").executeUpdate();
         institutionRepository.save(NursingInstitutionFixture.NURSING_INSTITUTION);
+        associationRepository.save(AssociationFixture.JEONJU_ASSOCIATION);
         socialworkerRepository.save(SocialWorkerFixture.SOCIAL_WORKER_1);
         socialworkerRepository.save(SocialWorkerFixture.SOCIAL_WORKER_MANAGER);
+    }
+
+    private String camelToSnake(String value) {
+        return value.replaceAll("(?<=[a-z])[A-Z]", "_$0").toLowerCase();
     }
 }

--- a/src/test/java/com/becareful/becarefulserver/community/api/CommentIntegrationTest.java
+++ b/src/test/java/com/becareful/becarefulserver/community/api/CommentIntegrationTest.java
@@ -1,0 +1,80 @@
+package com.becareful.becarefulserver.community.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.becareful.becarefulserver.common.IntegrationTest;
+import com.becareful.becarefulserver.common.WithSocialWorker;
+import com.becareful.becarefulserver.domain.community.domain.Post;
+import com.becareful.becarefulserver.domain.community.domain.PostBoard;
+import com.becareful.becarefulserver.domain.community.dto.request.CommentCreateRequest;
+import com.becareful.becarefulserver.domain.community.dto.request.CommentUpdateRequest;
+import com.becareful.becarefulserver.domain.community.repository.CommentRepository;
+import com.becareful.becarefulserver.domain.community.repository.PostBoardRepository;
+import com.becareful.becarefulserver.domain.community.repository.PostRepository;
+import com.becareful.becarefulserver.domain.community.service.CommentService;
+import com.becareful.becarefulserver.domain.common.vo.Gender;
+import com.becareful.becarefulserver.domain.nursing_institution.vo.InstitutionRank;
+import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
+import com.becareful.becarefulserver.domain.socialworker.domain.vo.AssociationRank;
+import com.becareful.becarefulserver.domain.socialworker.repository.SocialWorkerRepository;
+import com.becareful.becarefulserver.fixture.AssociationFixture;
+import com.becareful.becarefulserver.fixture.NursingInstitutionFixture;
+import com.becareful.becarefulserver.fixture.PostBoardFixture;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CommentIntegrationTest extends IntegrationTest {
+
+    @Autowired private CommentService commentService;
+    @Autowired private PostBoardRepository postBoardRepository;
+    @Autowired private PostRepository postRepository;
+    @Autowired private CommentRepository commentRepository;
+    @Autowired private SocialWorkerRepository socialWorkerRepository;
+
+    private SocialWorker createMember(String phone) {
+        SocialWorker member =
+                SocialWorker.create(
+                        "name",
+                        "nick",
+                        LocalDate.now(),
+                        Gender.FEMALE,
+                        phone,
+                        InstitutionRank.SOCIAL_WORKER,
+                        AssociationRank.MEMBER,
+                        true,
+                        NursingInstitutionFixture.NURSING_INSTITUTION);
+        member.joinAssociation(AssociationFixture.JEONJU_ASSOCIATION, AssociationRank.MEMBER);
+        return socialWorkerRepository.save(member);
+    }
+
+    private PostBoard createBoard() {
+        return postBoardRepository.save(PostBoardFixture.협회공지);
+    }
+
+    private Post createPost(PostBoard board, SocialWorker author) {
+        return postRepository.save(Post.create("t", "c", false, null, board, author));
+    }
+
+    @Test
+    @WithSocialWorker(phoneNumber = "01099999999")
+    void 댓글_수정과_삭제가_성공한다() {
+        SocialWorker member = createMember("01099999999");
+        PostBoard board = createBoard();
+        Post post = createPost(board, member);
+
+        Long commentId =
+                commentService.createComment(
+                        "association-notice", post.getId(), new CommentCreateRequest("hello"));
+
+        commentService.updateComment(
+                "association-notice", post.getId(), commentId, new CommentUpdateRequest("hi"));
+
+        assertThat(commentRepository.findById(commentId).get().getContent()).isEqualTo("hi");
+
+        commentService.deleteComment("association-notice", post.getId(), commentId);
+
+        assertThat(commentRepository.findById(commentId)).isEmpty();
+    }
+}
+

--- a/src/test/java/com/becareful/becarefulserver/community/api/PostIntegrationTest.java
+++ b/src/test/java/com/becareful/becarefulserver/community/api/PostIntegrationTest.java
@@ -1,8 +1,28 @@
 package com.becareful.becarefulserver.community.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.becareful.becarefulserver.common.IntegrationTest;
+import com.becareful.becarefulserver.common.WithSocialWorker;
+import com.becareful.becarefulserver.domain.association.domain.Association;
+import com.becareful.becarefulserver.domain.association.repository.AssociationRepository;
+import com.becareful.becarefulserver.domain.common.vo.Gender;
+import com.becareful.becarefulserver.domain.community.domain.BoardType;
+import com.becareful.becarefulserver.domain.community.domain.Post;
+import com.becareful.becarefulserver.domain.community.domain.PostBoard;
+import com.becareful.becarefulserver.domain.community.dto.request.PostCreateOrUpdateRequest;
 import com.becareful.becarefulserver.domain.community.repository.PostBoardRepository;
+import com.becareful.becarefulserver.domain.community.repository.PostRepository;
 import com.becareful.becarefulserver.domain.community.service.PostService;
+import com.becareful.becarefulserver.domain.nursing_institution.vo.InstitutionRank;
+import com.becareful.becarefulserver.domain.socialworker.domain.SocialWorker;
+import com.becareful.becarefulserver.domain.socialworker.domain.vo.AssociationRank;
+import com.becareful.becarefulserver.domain.socialworker.repository.SocialWorkerRepository;
+import com.becareful.becarefulserver.fixture.NursingInstitutionFixture;
+import com.becareful.becarefulserver.global.exception.exception.PostBoardException;
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class PostIntegrationTest extends IntegrationTest {
@@ -13,32 +33,81 @@ public class PostIntegrationTest extends IntegrationTest {
     @Autowired
     private PostBoardRepository postBoardRepository;
 
-    //    @Test
-    //    @WithSocialWorker(phoneNumber = "01012345679")
-    //    void 게시글_생성에_성공한다() {
-    //        PostCreateRequest request = new PostCreateRequest("title", "content", false);
-    //        PostBoard board = postBoardRepository.save(PostBoardFixture.협회공지);
-    //
-    //        postService.createPost(board.getId(), request);
-    //    }
-    //
-    //    @Test
-    //    @WithSocialWorker(phoneNumber = "01012345678")
-    //    void 작성권한이_없으면_게시글_생성에_실패한다() {
-    //        PostCreateRequest request = new PostCreateRequest("title", "content", false);
-    //        PostBoard board = postBoardRepository.save(PostBoardFixture.협회공지);
-    //
-    //        Assertions.assertThatThrownBy(() -> postService.createPost(board.getId(), request))
-    //                .isInstanceOf(PostBoardException.class);
-    //    }
-    //
-    //    @Test
-    //    @WithSocialWorker(phoneNumber = "01012345679")
-    //    void 게시글_수정에_성공한다() {
-    //        PostCreateRequest request = new PostCreateRequest("title", "content", false);
-    //        PostBoard board = postBoardRepository.save(PostBoardFixture.협회공지);
-    //        Long postId = postService.createPost(board.getId(), request);
-    //
-    //        postService.updatePost(board.getId(), postId, new PostUpdateRequest("title2", "content2", false));
-    //    }
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private SocialWorkerRepository socialWorkerRepository;
+
+    @Autowired
+    private AssociationRepository associationRepository;
+
+    private SocialWorker createMember(String phone, AssociationRank rank) {
+        SocialWorker member = SocialWorker.create(
+                "name",
+                "nick",
+                LocalDate.now(),
+                Gender.FEMALE,
+                phone,
+                InstitutionRank.SOCIAL_WORKER,
+                rank,
+                true,
+                NursingInstitutionFixture.NURSING_INSTITUTION);
+        Association association = associationRepository.findAll().get(0);
+        member.joinAssociation(association, rank);
+        return socialWorkerRepository.save(member);
+    }
+
+    private PostBoard createBoard() {
+        Association association = associationRepository.findAll().get(0);
+        PostBoard board = PostBoard.create(
+                BoardType.ASSOCIATION_NOTICE, AssociationRank.MEMBER, AssociationRank.MEMBER, association);
+        return postBoardRepository.save(board);
+    }
+
+    @Test
+    @WithSocialWorker(phoneNumber = "01010000000")
+    void 게시글_생성에_성공한다() {
+        createMember("01010000000", AssociationRank.MEMBER);
+        createBoard();
+
+        PostCreateOrUpdateRequest request =
+                new PostCreateOrUpdateRequest("title", "content", false, null, null, null, null);
+
+        Long postId = postService.createPost("association-notice", request);
+
+        assertThat(postRepository.findById(postId)).isPresent();
+    }
+
+    @Test
+    @WithSocialWorker(phoneNumber = "01020000000")
+    void 작성권한이_없으면_게시글_생성에_실패한다() {
+        createMember("01020000000", AssociationRank.NONE);
+        createBoard();
+
+        PostCreateOrUpdateRequest request =
+                new PostCreateOrUpdateRequest("title", "content", false, null, null, null, null);
+
+        assertThatThrownBy(() -> postService.createPost("association-notice", request))
+                .isInstanceOf(PostBoardException.class);
+    }
+
+    @Test
+    @WithSocialWorker(phoneNumber = "01030000000")
+    void 게시글_수정에_성공한다() {
+        createMember("01030000000", AssociationRank.MEMBER);
+        createBoard();
+
+        PostCreateOrUpdateRequest request =
+                new PostCreateOrUpdateRequest("title", "content", false, null, null, null, null);
+        Long postId = postService.createPost("association-notice", request);
+
+        postService.updatePost(
+                "association-notice",
+                postId,
+                new PostCreateOrUpdateRequest("title2", "content2", false, null, null, null, null));
+
+        Post post = postRepository.findById(postId).get();
+        assertThat(post.getTitle()).isEqualTo("title2");
+    }
 }

--- a/src/test/java/com/becareful/becarefulserver/fixture/NursingInstitutionFixture.java
+++ b/src/test/java/com/becareful/becarefulserver/fixture/NursingInstitutionFixture.java
@@ -6,6 +6,10 @@ import java.util.EnumSet;
 
 public class NursingInstitutionFixture {
 
-    public static NursingInstitution NURSING_INSTITUTION = NursingInstitution.create(
-            "행복요양기관", "code", 2024, EnumSet.noneOf(FacilityType.class), "031-123-1234", "도로명주소", "상세주소", "url");
+    public static NursingInstitution NURSING_INSTITUTION = create();
+
+    public static NursingInstitution create() {
+        return NursingInstitution.create(
+                "행복요양기관", "code", 2024, EnumSet.noneOf(FacilityType.class), "031-123-1234", "도로명주소", "상세주소", "url");
+    }
 }


### PR DESCRIPTION
## Summary
- implement `CommentUpdateRequest` DTO
- add `CommentException` and error messages
- extend `Comment` entity with update and author validation methods
- add update/delete methods in `CommentService`
- expose new endpoints in `CommentController`
- provide integration test covering update and delete workflow

## Testing
- `./gradlew test` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687dcc31626c83319285004594297ac3

close #146 